### PR TITLE
Fix specs for sqlite backend

### DIFF
--- a/app/models/macro_step.rb
+++ b/app/models/macro_step.rb
@@ -20,7 +20,7 @@ class MacroStep < ActiveRecord::Base
     # make a clean copy of ourself
     attrs = self.attributes.dup
     attrs.delete_if { |k,_| !record_class.columns.map(&:name).include?( k ) }
-    attrs.delete(:id)
+    attrs.delete('id')
 
     # parse each attribute for %ZONE%
     unless domain.nil?


### PR DESCRIPTION
While trying to fix the specs for sqlite I found that `self.attributes` returns a hash that uses strings as keys causing the `id` field to not being properly removed. Not sure why this works on mysql but on sqlite It sure doesn't.
