### PR TITLE
timestamps have "not null" contraints by default in rails3.

### DIFF
--- a/db/migrate/002_create_records.rb
+++ b/db/migrate/002_create_records.rb
@@ -7,9 +7,9 @@ class CreateRecords < ActiveRecord::Migration
       t.string :content, :null => false
       t.integer :ttl, :null => false
       t.integer :prio
-      t.integer :change_date, :null => false
+      t.integer :change_date, :null => true 
       
-      t.timestamps
+      t.timestamps :null => true
     end
     
     add_index :records, :domain_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,8 +40,8 @@ ActiveRecord::Schema.define(:version => 20120819220815) do
     t.integer  "user_id"
     t.string   "token",       :null => false
     t.text     "permissions", :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
     t.datetime "expires_at",  :null => false
   end
 
@@ -53,9 +53,8 @@ ActiveRecord::Schema.define(:version => 20120819220815) do
     t.integer  "notified_serial"
     t.string   "account"
     t.integer  "ttl",             :default => 86400
-    t.integer  "integer",         :default => 86400
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                            :null => false
+    t.datetime "updated_at",                            :null => false
     t.integer  "user_id"
     t.text     "notes"
   end
@@ -73,8 +72,8 @@ ActiveRecord::Schema.define(:version => 20120819220815) do
     t.integer  "position",                      :null => false
     t.boolean  "active",      :default => true
     t.string   "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
   end
 
   create_table "macros", :force => true do |t|
@@ -82,8 +81,8 @@ ActiveRecord::Schema.define(:version => 20120819220815) do
     t.string   "description"
     t.integer  "user_id"
     t.boolean  "active",      :default => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                     :null => false
+    t.datetime "updated_at",                     :null => false
   end
 
   create_table "record_templates", :force => true do |t|
@@ -93,18 +92,18 @@ ActiveRecord::Schema.define(:version => 20120819220815) do
     t.string   "content",          :null => false
     t.integer  "ttl",              :null => false
     t.integer  "prio"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",       :null => false
+    t.datetime "updated_at",       :null => false
   end
 
   create_table "records", :force => true do |t|
-    t.integer  "domain_id",                 :null => false
-    t.string   "name",                      :null => false
-    t.string   "type",        :limit => 11, :null => false
-    t.string   "content",                   :null => false
-    t.integer  "ttl",                       :null => false
+    t.integer  "domain_id",   :null => false
+    t.string   "name",        :null => false
+    t.string   "type",        :null => false
+    t.string   "content",     :null => false
+    t.integer  "ttl",         :null => false
     t.integer  "prio"
-    t.integer  "change_date",               :null => false
+    t.integer  "change_date", :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -113,22 +112,16 @@ ActiveRecord::Schema.define(:version => 20120819220815) do
   add_index "records", ["name", "type"], :name => "index_records_on_name_and_type"
   add_index "records", ["name"], :name => "index_records_on_name"
 
-  create_table "supermasters", :id => false, :force => true do |t|
-    t.string "ip",         :limit => 25, :default => "", :null => false
-    t.string "nameserver",               :default => "", :null => false
-    t.string "account",    :limit => 40
-  end
-
   create_table "users", :force => true do |t|
     t.string   "login"
     t.string   "email"
     t.string   "encrypted_password",        :limit => 128, :default => "",        :null => false
-    t.string   "password_salt",                            :default => "",        :null => false
+    t.string   "password_salt",             :limit => 40,  :default => "",        :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "remember_token"
     t.datetime "remember_token_expires_at"
-    t.string   "confirmation_token"
+    t.string   "confirmation_token",        :limit => 40
     t.datetime "confirmed_at"
     t.string   "state",                                    :default => "passive"
     t.datetime "deleted_at"
@@ -142,8 +135,8 @@ ActiveRecord::Schema.define(:version => 20120819220815) do
   create_table "zone_templates", :force => true do |t|
     t.string   "name"
     t.integer  "ttl",        :default => 86400
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
     t.integer  "user_id"
   end
 


### PR DESCRIPTION
The records table needs to have the "not null" constraints removed for the three timestamps (created_at, updated_at, change_date) to support SLAVE domains.
pdns has no knowledge of the fields, leaves them undefined when inserting records.

Additionally the schema.rb was updated to to reflect the current state of the migrations in rails 3.
