### PR TITLE
add support for specifying the domain type in the zone template.

### DIFF
--- a/app/views/domains/_new.html.haml
+++ b/app/views/domains/_new.html.haml
@@ -20,15 +20,6 @@
       %td{:width => "300"}=t :label_domain_name
       %td= f.text_field :name
       %td= help_icon('help-domain')
-    %tr
-      %td=t :label_domain_type
-      %td
-        = f.select :type, ['NATIVE','MASTER','SLAVE']
-      %td= help_icon('help-type')
-    %tr#master-address{ :style => 'display: none' }
-      %td=t :label_domain_master_address
-      %td= f.text_field :master
-      %td= help_icon('help-master')
     %tr#zone-templates
       %td=t :label_domain_zone_template
       %td
@@ -39,6 +30,15 @@
             =link_to((t :label_create_zone_templates), new_zone_template_path)
             =t :label_zone_for_eazy_management
       %td &nbsp;
+    %tr#domain-type
+      %td=t :label_domain_type
+      %td
+        = f.select :type, ['NATIVE','MASTER','SLAVE']
+      %td= help_icon('help-type')
+    %tr#master-address{ :style => 'display: none' }
+      %td=t :label_domain_master_address
+      %td= f.text_field :master
+      %td= help_icon('help-master')
 
 
   #no-template-input

--- a/app/views/templates/_form.html.haml
+++ b/app/views/templates/_form.html.haml
@@ -13,6 +13,14 @@
       %td= t :label_template_zone_ttl
       %td &nbsp;
       %td= f.text_field :ttl, :size => 6
+    %tr
+      %td= t :label_template_zone_type
+      %td &nbsp;
+      %td= f.select :type, ['NATIVE','MASTER','SLAVE'] 
+    %tr
+      %td= t :label_template_zone_master
+      %td &nbsp;
+      %td= f.text_field :master, :size => 15 
     - if User.active_owners.any?
       %tr
         %td= t :label_template_zone_owner

--- a/app/views/templates/show.html.haml
+++ b/app/views/templates/show.html.haml
@@ -25,6 +25,9 @@
     %td= t :label_template_zone_ttl
     %td= @zone_template.ttl
   %tr
+    %td= t :label_template_zone_type
+    %td= @zone_template.type.humanize
+  %tr
     %td= t :label_template_zone_owner
     %td
       - if @zone_template.user

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -402,6 +402,8 @@ en:
     The name by which our zone templates will be known.
   label_template_zone_name: "Name"
   label_template_zone_ttl: "TTL"
+  label_template_zone_type: "Type"
+  label_template_zone_master: "Master IP"
   label_template_zone_owner: "Owner"
 
 # Templates index

--- a/db/migrate/20130429134229_add_type_master_to_zone_template.rb
+++ b/db/migrate/20130429134229_add_type_master_to_zone_template.rb
@@ -1,0 +1,7 @@
+class AddTypeMasterToZoneTemplate < ActiveRecord::Migration
+  def change
+    add_column :zone_templates, :type, :string, :default => 'NATIVE'
+    add_column :zone_templates, :master, :string
+  end
+end
+ 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130419205056) do
+ActiveRecord::Schema.define(:version => 20130429134229) do
 
   create_table "audits", :force => true do |t|
     t.integer  "auditable_id"
@@ -139,6 +139,8 @@ ActiveRecord::Schema.define(:version => 20130419205056) do
     t.datetime "created_at",                    :null => false
     t.datetime "updated_at",                    :null => false
     t.integer  "user_id"
+    t.string   "type",       :default => "NATIVE"
+    t.string   "master"
   end
 
 end

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -34,8 +34,10 @@ $(document).ready(function() {
   $('#domain_zone_template_id').change(function() {
     if ( $(this).val() == '' ) {
       $('#no-template-input').show();
+      $('#domain-type').show();
     } else {
       $('#no-template-input').hide();
+      $('#domain-type').hide();
     }
   });
 


### PR DESCRIPTION
Currently when creating a domain from a template the domain type is always set to be 'NATIVE' and the value from the drop-down menu is ignored.
This commits allows to specify the type (and master for type SLAVE) in the zone template and the domain will be created accordingly.
