### PR TITLE
add a vagrant setup for testing / developing / demoing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ More information:
 
 _Note on versions:_ PowerDNS on Rails is version-less, and the master branch will _nearly_ always have stable useable code.
 
+## Demo 
+
+There is now a vagrant/virtualbox demo environment included.  
+You will need to have [virtualbox](https://www.virtualbox.org/) and [vagrant](http://www.vagrantup.com) already installed.  
+To see powerdns-on-rails in action:  ( _only tested with vagrant on linux_ )
+
+* clone this repo
+* change into the new directory
+* `$ vagrant up`
+* point your browser at `http://localhost:3000`
+* login with `admin@example.com` and `secret`
+
+The first time you run this it will download a base virtual machine (401MB) and bootstrap a working powerdns-on-rails system.  
+Currently there will be no working powerdns server but powerdns-on-rails will be fully functional still.
+
 ## Features (current and planned)
 
 * RESTful architecture to support rich UI and API access

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "pdns-on-rails-precise64"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://aussie.lunix.com.au/files/vagrantboxes/pdns-on-rails-precise64.box"
+  config.vm.provision :shell, :path => "script/provision"
+end

--- a/script/provision
+++ b/script/provision
@@ -1,0 +1,12 @@
+#!/bin/bash -x
+
+apt-get install -yq libsqlite3-dev libsqlite3-0 libpq5 postgresql postgresql-9.1 postgresql-client-9.1 postgresql-client-common postgresql-common ssl-cert libpq-dev
+
+su vagrant -c "git clone https://github.com/kennethkalmer/powerdns-on-rails.git"
+su vagrant -c "source /etc/profile.d/rbenv.sh && cd powerdns-on-rails && bundle install"
+su vagrant -c "cd powerdns-on-rails && cp config/database.yml.template config/database.yml"
+su vagrant -c 'source /etc/profile.d/rbenv.sh && cd powerdns-on-rails && SECRET=`rake secret` && sed -i "/^    config.active_record.whitelist_attributes = false/a \ \ \ \ config.secret_token = \"$SECRET\"" config/application.rb'
+su vagrant -c "source /etc/profile.d/rbenv.sh && cd powerdns-on-rails && DB=sqlite RAILS_ENV=test rake db:migrate"
+su vagrant -c "source /etc/profile.d/rbenv.sh && cd powerdns-on-rails && DB=sqlite RAILS_ENV=test rake db:seed"
+su vagrant -c "source /etc/profile.d/rbenv.sh && cd powerdns-on-rails && DB=sqlite RAILS_ENV=test script/rails s -d"
+


### PR DESCRIPTION
This adds a Vagrantfile and provisioning script.
I wanted a way to quickly get this in the hands of others so they could see the functionality of powerdns-on-rails and thought I'd contribute it back.
The reason this uses a basebox on my server is it has `rbenv` already built and setup.
