### PR TITLE
Ensure all TXT and SPF records are quoted

### DIFF
--- a/app/models/spf.rb
+++ b/app/models/spf.rb
@@ -14,4 +14,6 @@ class SPF < Record
 
   validates_presence_of :content
 
+  validates :content, format: { with: /\A".*"\Z/, message: "SPF records must be in quotes" }
+
 end

--- a/app/models/txt.rb
+++ b/app/models/txt.rb
@@ -11,5 +11,7 @@
 class TXT < Record
   
   validates_presence_of :content
+
+  validates :content, format: { with: /\A".*"\Z/, message: "TXT records must be in quotes" }
   
 end


### PR DESCRIPTION
According to PowerDNS, "SPF records need quotes, it is a historical anomaly that TXT records can do without. We're not repeating that with SPF."
    - http://wiki.powerdns.com/trac/ticket/249

Note: If there are any existing SPF records which are not quoted, THEY WILL NOT BE HONOURED by PowerDNS. Since this changes email-deliverability, this change does not attempt to fix this. However, if you make any CHANGES, you must add the quotes from here on in.

Fixes https://github.com/kennethkalmer/powerdns-on-rails/issues/6
